### PR TITLE
fix: dual webkit and correctness fix

### DIFF
--- a/survey_app/src/main/java/org/opendatakit/survey/activities/MainMenuActivity.java
+++ b/survey_app/src/main/java/org/opendatakit/survey/activities/MainMenuActivity.java
@@ -1527,7 +1527,7 @@ public class MainMenuActivity extends BaseActivity implements IOdkSurveyActivity
   }
 
   @Override
-  public String getResponseJSON() {
+  public String getResponseJSON(String unused) {
     if ( queueResponseJSON.isEmpty() ) {
       return null;
     }
@@ -1575,13 +1575,19 @@ public class MainMenuActivity extends BaseActivity implements IOdkSurveyActivity
     ODKWebView view = (ODKWebView) findViewById(R.id.webkit);
 
     if (requestCode == HANDLER_ACTIVITY_CODE) {
-      try {
-        DoActionUtils.processActivityResult(this, view, resultCode, intent,
-            dispatchStringWaitingForData, actionWaitingForData);
-      } finally {
-        dispatchStringWaitingForData = null;
-        actionWaitingForData = null;
-      }
+      // save persisted values into a local variable
+      String dispatchString = dispatchStringWaitingForData;
+      String action = actionWaitingForData;
+
+      // clear the persisted values
+      dispatchStringWaitingForData = null;
+      actionWaitingForData = null;
+
+      // DoActionUtils may invoke queueActionOutcome and add the response to the
+      // queued actions. If it does, it will then also signal the view that there
+      // are responses available. Clear the persisted values before this signal.
+      DoActionUtils.processActivityResult(this, view, resultCode, intent,
+          dispatchString, action);
     } else if (requestCode == SYNC_ACTIVITY_CODE) {
       this.swapToFragmentView((currentFragment == null) ? ScreenList.FORM_CHOOSER : currentFragment);
     }

--- a/survey_app/src/main/java/org/opendatakit/survey/logic/SurveyDataExecutorProcessor.java
+++ b/survey_app/src/main/java/org/opendatakit/survey/logic/SurveyDataExecutorProcessor.java
@@ -29,6 +29,10 @@ import java.util.Map;
  */
 public class SurveyDataExecutorProcessor extends ExecutorProcessor {
 
+  /**
+   * No-op constructor
+   * @param context
+   */
   public SurveyDataExecutorProcessor(ExecutorContext context) {
     super(context);
   }


### PR DESCRIPTION
Add fragmentID argument to getResponseJSON().
Since DoActionUtils.processActivityResult() can signal the webkit, 
we should clear the dispatch and action strings prior to the signal
just in case the signal gets processed on the webkit UI thread
before we return from this method (unclear if the UI threads are the same).

Dependent upon #https://github.com/opendatakit/androidcommon/pull/17