### PR TITLE
Fix onActivityResult in SplashScreenActivity

### DIFF
--- a/survey_app/src/main/java/org/opendatakit/survey/activities/SplashScreenActivity.java
+++ b/survey_app/src/main/java/org/opendatakit/survey/activities/SplashScreenActivity.java
@@ -344,6 +344,12 @@ public class SplashScreenActivity extends BaseLauncherActivity {
 
   @Override
   public void onActivityResult(int requestCode, int resultCode, Intent intent) {
+    super.onActivityResult(requestCode, resultCode, intent);
+
+    if (resultCode != ACTION_CODE) {
+      return;
+    }
+
     setResult(resultCode, intent);
     WebLogger.getLogger(appName).i(TAG,
         "MainMenu finish()'d back to SplashScreen: " + (requestCode == ACTION_CODE ?


### PR DESCRIPTION
SplashScreenActivity's onActivityResult should call super's onActivityResult. 

Otherwise if initialization is done but Services doesn't have its permissions granted, upon return from Services, SplashScreenActivity of Survey will be destroyed. 