### PR TITLE
Increased text size of "Select the form to open" from 14sp to 21sp.

### DIFF
--- a/survey_app/src/main/res/layout/form_chooser_list.xml
+++ b/survey_app/src/main/res/layout/form_chooser_list.xml
@@ -29,7 +29,7 @@ the License.
         android:paddingRight="8dip"
         android:paddingTop="4dip"
         android:text="@string/select_form_to_edit"
-        android:textSize="14sp" />
+        android:textSize="21sp" />
 
     <ListView
         android:id="@android:id/list"


### PR DESCRIPTION
The header text for the form list in ODK Survey "Select the form to open" was quite small and hard to notice. I have increased its text size from 14 sp to 21 sp.
closes #1374