### PR TITLE
Replace support-v13 ActivityCompat with support-v4 ActivityCompat

### DIFF
--- a/survey_app/build.gradle
+++ b/survey_app/build.gradle
@@ -113,6 +113,7 @@ dependencies {
     implementation fileTree(include: '*.jar', dir: 'libs')
     implementation 'com.android.support:support-annotations:27.1.0'
     implementation 'com.android.support:support-v13:27.1.0'
+    implementation 'com.android.support:support-v4:27.1.0'
     implementation 'com.google.firebase:firebase-core:11.8.0'
     implementation ('com.crashlytics.sdk.android:crashlytics:2.9.1@aar') {
         transitive =true;

--- a/survey_app/src/main/java/org/opendatakit/survey/activities/GeoPointActivity.java
+++ b/survey_app/src/main/java/org/opendatakit/survey/activities/GeoPointActivity.java
@@ -26,7 +26,7 @@ import android.location.LocationManager;
 import android.location.LocationProvider;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
-import android.support.v13.app.ActivityCompat;
+import android.support.v4.app.ActivityCompat;
 import android.util.Log;
 import android.widget.Toast;
 import org.opendatakit.activities.BaseActivity;


### PR DESCRIPTION
ActivityCompat is deprecated in support library 27.1.0 and replaced by ActivityCompat in support-v4.
This pull request replaces usage of v13 ActivityCompat with v4 ActivityCompat.