### PR TITLE
Fix Crash when UI states do not align in Survey

### DIFF
--- a/survey_app/src/main/java/org/opendatakit/survey/fragments/InitializationFragment.java
+++ b/survey_app/src/main/java/org/opendatakit/survey/fragments/InitializationFragment.java
@@ -188,12 +188,15 @@ public class InitializationFragment extends Fragment implements InitializationLi
   }
 
   private void updateProgressDialog(String displayString) {
-    if (!msgManager.displayingProgressDialog()) {
-      msgManager.createProgressDialog(mainDialogTitle, getString(R.string.please_wait),
-              getParentFragmentManager());
-    } else {
-      if (msgManager.hasDialogBeenCreated()) {
-        msgManager.updateProgressDialogMessage(displayString, getParentFragmentManager());
+
+    if (isVisible() && getActivity() != null) {
+      if (!msgManager.displayingProgressDialog()) {
+        msgManager.createProgressDialog(mainDialogTitle, getString(R.string.please_wait),
+                getParentFragmentManager());
+      } else {
+        if (msgManager.hasDialogBeenCreated()) {
+          msgManager.updateProgressDialogMessage(displayString, getParentFragmentManager());
+        }
       }
     }
   }


### PR DESCRIPTION
## This is a PR for issue [475](https://github.com/odk-x/tool-suite-X/issues/475), and the PR contains the following:

### Overview
The crash log shows that an IllegalStateException was thrown in the `Survey app`. The breakdown of the stack trace:

1. The crash was from the `createProgressDialog` function in the `AlertNProgessMsgFragmentMger`, which occurs when trying to create a progress dialog after the dialogs have been cleared for shutdown.
2. The `createProgressDialog` function is called from the `updateProgressDialog` function in the `InitializationFragment` 
3. The `updateProgressDialog` function was called after the fragment has been stopped or destroyed, which lead to an `IllegalStateException`

### Proposed Fix 
1. The `updateProgressDialog` function should be called only when the fragment is in a valid state to display a progress dialog.
2. Check the fragment's lifecycle state before updating the dialog by using: `if (isVisible() && getActivity() != null)`
3. This will ensure that the `updateProgressDialog` function will only attempt to update the dialog if the fragment is currently visible and attached to an activity, Thereby preventing the `IllegalStateException` from being thrown


### Fix: Screenshots of the  `updateProgressDialog` function in `InitializationFragment.java`
![Update](https://github.com/odk-x/survey/assets/61055200/b5178a13-2919-423c-bc8e-012b8a2031e7)
