### PR TITLE
Updated fonts for headings and body text

### DIFF
--- a/survey_app/src/main/res/layout/copy_expansion_files_layout.xml
+++ b/survey_app/src/main/res/layout/copy_expansion_files_layout.xml
@@ -28,6 +28,7 @@ the License.
         android:paddingRight="20dp"
         android:text="@string/initializing"
         android:textColor="@color/black"
-        android:textSize="21sp" />
+        android:textSize="21sp"
+        android:fontFamily="@font/montserrat"/>
 
 </LinearLayout>

--- a/survey_app/src/main/res/layout/form_chooser_list.xml
+++ b/survey_app/src/main/res/layout/form_chooser_list.xml
@@ -29,7 +29,8 @@ the License.
         android:paddingRight="8dip"
         android:paddingTop="4dip"
         android:text="@string/select_form_to_edit"
-        android:textSize="21sp" />
+        android:textSize="21sp"
+        android:fontFamily="@font/montserrat"/>
 
     <ListView
         android:id="@android:id/list"
@@ -46,6 +47,7 @@ the License.
         android:paddingRight="20dp"
         android:text="@string/no_items_display_forms"
         android:textColor="@color/black"
-        android:textSize="21sp" />
+        android:textSize="21sp"
+        android:fontFamily="@font/montserrat"/>
 
 </LinearLayout>

--- a/survey_app/src/main/res/layout/shortcut_item.xml
+++ b/survey_app/src/main/res/layout/shortcut_item.xml
@@ -23,5 +23,6 @@
         android:paddingLeft="20dp"
         android:paddingRight="20dp"
         android:textColor="@color/black"
-		android:textAppearance="?android:attr/textAppearanceLarge"/>
+		android:textAppearance="?android:attr/textAppearanceLarge"
+		android:fontFamily="@font/montserrat" />
 </LinearLayout>

--- a/survey_app/src/main/res/layout/splash_screen.xml
+++ b/survey_app/src/main/res/layout/splash_screen.xml
@@ -36,6 +36,8 @@
 			android:layout_height="wrap_content"
 			android:gravity="center_vertical|left"
 			android:paddingBottom="5dip">
+
+			<!-- Font for this should be Montserrat -->
 			<TextView
 				android:id="@+id/text"
 				android:text="@string/app_name"
@@ -44,8 +46,11 @@
 				android:background="@android:color/transparent"
 				android:textSize="22sp"
 				android:textStyle="bold"
+				android:fontFamily="@font/montserrat"
 				android:paddingLeft="7dip"
 				android:paddingRight="7dip" />
+
+			<!-- Font for this should be Montserrat -->
 			<TextView
 				android:id="@+id/url"
 				android:text="@string/app_url"
@@ -53,6 +58,7 @@
 				android:layout_height="fill_parent"
 				android:background="@android:color/transparent"
 				android:textSize="14sp"
+				android:fontFamily="@font/montserrat"
 				android:paddingLeft="7dip"
 				android:paddingRight="7dip" />
 		</LinearLayout>

--- a/survey_app/src/main/res/layout/splash_screen.xml
+++ b/survey_app/src/main/res/layout/splash_screen.xml
@@ -37,7 +37,6 @@
 			android:gravity="center_vertical|left"
 			android:paddingBottom="5dip">
 
-			<!-- Font for this should be Montserrat -->
 			<TextView
 				android:id="@+id/text"
 				android:text="@string/app_name"
@@ -50,7 +49,6 @@
 				android:paddingLeft="7dip"
 				android:paddingRight="7dip" />
 
-			<!-- Font for this should be Montserrat -->
 			<TextView
 				android:id="@+id/url"
 				android:text="@string/app_url"

--- a/survey_app/src/main/res/layout/splash_screen.xml
+++ b/survey_app/src/main/res/layout/splash_screen.xml
@@ -36,7 +36,6 @@
 			android:layout_height="wrap_content"
 			android:gravity="center_vertical|left"
 			android:paddingBottom="5dip">
-
 			<TextView
 				android:id="@+id/text"
 				android:text="@string/app_name"

--- a/survey_app/src/main/res/layout/two_item.xml
+++ b/survey_app/src/main/res/layout/two_item.xml
@@ -15,7 +15,8 @@
 			android:gravity="center_vertical"
 			android:layout_alignParentTop="true"
 			android:layout_alignParentLeft="true"
-			android:textAppearance="?android:attr/textAppearanceLarge"/>
+			android:textAppearance="?android:attr/textAppearanceLarge"
+			android:fontFamily="@font/montserrat"/>
    		<TextView
 			android:id="@+id/text3"
 			android:layout_width="fill_parent"
@@ -23,7 +24,8 @@
 			android:visibility="gone"
 			android:layout_below="@+id/text1"
 			android:layout_alignParentLeft="true"
-			android:textAppearance="?android:attr/textAppearanceSmall"/>
+			android:textAppearance="?android:attr/textAppearanceSmall"
+			android:fontFamily="@font/montserrat"/>
 		<TextView
 			android:id="@+id/text2"
 			android:layout_width="fill_parent"
@@ -31,5 +33,6 @@
 			android:gravity="center_vertical"
 			android:layout_below="@+id/text3"
 			android:layout_alignParentLeft="true"
-			android:textAppearance="?android:attr/textAppearanceSmall"/>
+			android:textAppearance="?android:attr/textAppearanceSmall"
+			android:fontFamily="@font/sourcesanspro_regular"/>
 </RelativeLayout>

--- a/survey_app/src/main/res/layout/web_view_container.xml
+++ b/survey_app/src/main/res/layout/web_view_container.xml
@@ -28,7 +28,6 @@ the License.
 			android:visibility="gone" />
 
 	<!-- empty view -->
-	<!-- Font for this should be Montserrat -->
 	<TextView
 			android:id="@android:id/empty"
 			android:gravity="center"

--- a/survey_app/src/main/res/layout/web_view_container.xml
+++ b/survey_app/src/main/res/layout/web_view_container.xml
@@ -28,11 +28,13 @@ the License.
 			android:visibility="gone" />
 
 	<!-- empty view -->
+	<!-- Font for this should be Montserrat -->
 	<TextView
 			android:id="@android:id/empty"
 			android:gravity="center"
 			android:layout_width="match_parent"
 			android:layout_height="match_parent"
-			android:text="@string/database_unavailable" />
+			android:text="@string/database_unavailable"
+			android:fontFamily="@font/montserrat"/>
 
 </LinearLayout>

--- a/survey_app/src/main/res/xml/preferences.xml
+++ b/survey_app/src/main/res/xml/preferences.xml
@@ -33,7 +33,7 @@
 			android:key="common.username"
 			android:title="@string/username"
 			android:inputType="textNoSuggestions"
-			android:dialogTitle="@string/change_username"
+			android:dialogTitle="@string/change_username" 
 			android:persistent="false"/>
 		<EditTextPreference
 			android:id="@+id/password"

--- a/survey_app/src/main/res/xml/preferences.xml
+++ b/survey_app/src/main/res/xml/preferences.xml
@@ -33,7 +33,7 @@
 			android:key="common.username"
 			android:title="@string/username"
 			android:inputType="textNoSuggestions"
-			android:dialogTitle="@string/change_username" 
+			android:dialogTitle="@string/change_username"
 			android:persistent="false"/>
 		<EditTextPreference
 			android:id="@+id/password"


### PR DESCRIPTION
This PR is a fix for [this issue](https://github.com/odk-x/tool-suite-X/issues/498)

I upated the headings font to Montserrat and the paragraphs font to Source Sans Pro
<img width="770" alt="Screenshot 2024-10-16 at 15 08 32" src="https://github.com/user-attachments/assets/4c5f2035-a5c4-4947-a52e-01a5d8114863">

